### PR TITLE
Don't use active support features

### DIFF
--- a/lib/smart_proxy_dynflow/api.rb
+++ b/lib/smart_proxy_dynflow/api.rb
@@ -13,7 +13,7 @@ module Proxy
 
       post "/tasks/?" do
         params = parse_json_body
-        trigger_task(params['action_name'].constantize, params['action_input']).to_json
+        trigger_task(::Dynflow::Utils.constantize(params['action_name']), params['action_input']).to_json
       end
 
       post "/tasks/:task_id/cancel" do |task_id|

--- a/smart_proxy_dynflow.gemspec
+++ b/smart_proxy_dynflow.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rack-test', '~> 0')
   gem.add_development_dependency('rubocop', '0.32.1')
 
-  gem.add_runtime_dependency('dynflow', "~> 0.8.3")
+  gem.add_runtime_dependency('dynflow', "~> 0.8.4")
   gem.add_runtime_dependency('sequel')
   gem.add_runtime_dependency('sqlite3')
 end

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'json'
+require 'smart_proxy_dynflow/api.rb'
 
 class Proxy::Dynflow
   class ApiTest < Minitest::Spec


### PR DESCRIPTION
Luckily, the Dynflow already contains the code we need.

Depends on https://github.com/Dynflow/dynflow/pull/163