### PR TITLE
Postpone the Dynflow world initialization

### DIFF
--- a/lib/smart_proxy_dynflow/http_config.ru
+++ b/lib/smart_proxy_dynflow/http_config.ru
@@ -2,7 +2,7 @@ require 'smart_proxy_dynflow/api'
 
 map "/dynflow" do
   map '/console' do
-    run Proxy::Dynflow.instance.web_console
+    run Proxy::Dynflow.web_console
   end
 
   map '/'do

--- a/lib/smart_proxy_dynflow/testing.rb
+++ b/lib/smart_proxy_dynflow/testing.rb
@@ -11,6 +11,7 @@ module Proxy
     module Testing
       class << self
         def create_world(&block)
+          Proxy::Dynflow.ensure_initialized
           Proxy::Dynflow.instance.create_world do |config|
             config.exit_on_terminate = false
             config.auto_terminate    = false


### PR DESCRIPTION
We can't initalize the dynflow world sooner than the smart proxy forks in
production, because otherwise we loose the file descriptors we need to open at
the initialization phase.

We also add a hooking mechanism for other plugins using dynflow/concurrent
ruby for after_initialization tasks