### PR TITLE
refs #11827 - add api call to return count of tasks with a state

### DIFF
--- a/lib/smart_proxy_dynflow/api.rb
+++ b/lib/smart_proxy_dynflow/api.rb
@@ -23,6 +23,10 @@ module Proxy
       get "/tasks/:task_id/status" do |task_id|
         task_status(task_id).to_json
       end
+
+      get "/tasks/count" do
+        tasks_count(params['state']).to_json
+      end
     end
   end
 end

--- a/lib/smart_proxy_dynflow/helpers.rb
+++ b/lib/smart_proxy_dynflow/helpers.rb
@@ -23,6 +23,12 @@ module Proxy
         status 404
         {}
       end
+
+      def tasks_count(state)
+        filter = state ? { :filters => { :state => [state] } } : {}
+        tasks = world.persistence.find_execution_plans(filter)
+        { :count => tasks.count, :state => state || 'all' }
+      end
     end
   end
 end

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -62,5 +62,20 @@ class Proxy::Dynflow
         execution_plan.result.must_equal :success
       end
     end
+
+    describe 'GET /tasks/count' do
+      it 'counts the actions in state' do
+        get "/tasks/count", :state => 'stopped'
+        response = JSON.load(last_response.body)
+        old_count = response['count']
+
+        triggered = WORLD.trigger(DummyAction)
+        wait_until { WORLD.persistence.load_execution_plan(triggered.id).state == :stopped }
+
+        get "/tasks/count", :state => 'stopped'
+        response = JSON.load(last_response.body)
+        response['count'].must_equal old_count + 1
+      end
+    end
   end
 end


### PR DESCRIPTION
I want to be able to query the proxy for the number of currently running actions before distributing the new tasks when doing the load balancing.

It's a pretty simplistic round robin, not sure if want to do something fancier.