### PR TITLE
Fixes #11366 - adds dynflow persistance

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ task :default => :test
 
 desc 'Test Dynflow plugin.'
 Rake::TestTask.new(:test) do |t|
+  ENV['DYNFLOW_DB_CONN_STRING'] = 'sqlite:/'
   t.libs << '.'
   t.libs << 'lib'
   t.libs << 'test'

--- a/lib/smart_proxy_dynflow.rb
+++ b/lib/smart_proxy_dynflow.rb
@@ -18,7 +18,16 @@ class Proxy::Dynflow
   end
 
   def persistence_conn_string
-    ENV['DYNFLOW_DB_CONN_STRING'] || 'sqlite:/'
+    db_conn_string = 'sqlite:/'
+
+    db_file = Proxy::Dynflow::Plugin.settings.database
+    if db_file.nil? || db_file.empty?
+      Proxy::Log.logger.warn "Could not open DB for dynflow at '#{db_file}', will keep data in memory. Restart will drop all dynflow data."
+    else
+      db_conn_string += "/#{db_file}"
+    end
+
+    ENV['DYNFLOW_DB_CONN_STRING'] || db_conn_string
   end
 
   def persistence_adapter

--- a/lib/smart_proxy_dynflow/plugin.rb
+++ b/lib/smart_proxy_dynflow/plugin.rb
@@ -4,6 +4,7 @@ class Proxy::Dynflow
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
     settings_file "dynflow.yml"
+    default_settings :database => '/var/spool/foreman-proxy/dynflow/dynflow.sqlite'
     plugin :dynflow, Proxy::Dynflow::VERSION
   end
 end

--- a/settings.d/dynflow.yml.example
+++ b/settings.d/dynflow.yml.example
@@ -1,2 +1,3 @@
 ---
 :enabled: true
+:database: /var/spool/foreman-proxy/dynflow/dynflow.sqlite


### PR DESCRIPTION
will need to create `/var/spool/foreman-proxy/dynflow` in package spec, see https://github.com/theforeman/foreman-packaging/blob/rpm/develop/rubygem-smart_proxy_openscap/rubygem-smart_proxy_openscap.spec#L5 for an example