### PR TITLE
Fixes #13523 - use in-memory sqlite for tests

### DIFF
--- a/lib/smart_proxy_dynflow/testing.rb
+++ b/lib/smart_proxy_dynflow/testing.rb
@@ -11,6 +11,7 @@ module Proxy
     module Testing
       class << self
         def create_world(&block)
+          Proxy::Dynflow::Plugin.settings.database = nil
           Proxy::Dynflow.ensure_initialized
           Proxy::Dynflow.instance.create_world do |config|
             config.exit_on_terminate = false


### PR DESCRIPTION
No need to worry about the creation of the sqlite file then.