### PR TITLE
Fixes #11363 - Smart proxy dynflow console auth

### DIFF
--- a/lib/smart_proxy_dynflow.rb
+++ b/lib/smart_proxy_dynflow.rb
@@ -65,6 +65,12 @@ class Proxy::Dynflow
         # closing opened file descriptors)
         # TODO: extend smart proxy to enable hooks that happen after
         # the forking
+
+        if Proxy::Dynflow::Plugin.settings.console_auth
+          authorize_with_trusted_hosts
+          authorize_with_ssl_client
+        end
+
         Proxy::Dynflow.ensure_initialized
         set :world, Proxy::Dynflow.world
       end

--- a/lib/smart_proxy_dynflow/plugin.rb
+++ b/lib/smart_proxy_dynflow/plugin.rb
@@ -5,6 +5,7 @@ class Proxy::Dynflow
 
     settings_file "dynflow.yml"
     default_settings :database => '/var/lib/foreman-proxy/dynflow/dynflow.sqlite'
+    default_settings :console_auth => true
     plugin :dynflow, Proxy::Dynflow::VERSION
   end
 end

--- a/settings.d/dynflow.yml.example
+++ b/settings.d/dynflow.yml.example
@@ -1,3 +1,4 @@
 ---
 :enabled: true
 :database: /var/lib/foreman-proxy/dynflow/dynflow.sqlite
+:console_auth: true


### PR DESCRIPTION
Plain HTTP remains freely accessible, connections over HTTPS require a client SSL certificate