### PR TITLE
fixes #14314 - use logger instead of Proxy::Log for logging

### DIFF
--- a/lib/smart_proxy_dynflow.rb
+++ b/lib/smart_proxy_dynflow.rb
@@ -6,6 +6,8 @@ require 'smart_proxy_dynflow/callback'
 require 'smart_proxy_dynflow/helpers'
 
 class Proxy::Dynflow
+  include ::Proxy::Log
+
   attr_accessor :world
 
   def initialize
@@ -22,7 +24,7 @@ class Proxy::Dynflow
 
     db_file = Proxy::Dynflow::Plugin.settings.database
     if db_file.nil? || db_file.empty?
-      Proxy::Log.logger.warn "Could not open DB for dynflow at '#{db_file}', will keep data in memory. Restart will drop all dynflow data."
+      logger.warn "Could not open DB for dynflow at '#{db_file}', will keep data in memory. Restart will drop all dynflow data."
     else
       db_conn_string += "/#{db_file}"
     end


### PR DESCRIPTION
Tests are failing due to change in smart proxy

```
/var/lib/workspace/workspace/test_proxy_plugin_matrix/ruby/2.0.0/lib/smart_proxy_dynflow.rb:25:in `persistence_conn_string': undefined method `logger' for Proxy::Log:Module (NoMethodError)
```