### PR TITLE
Fixes #15442 - use separate settings for client certs

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -2,8 +2,15 @@
 # Path to dynflow database, leave blank for in-memory non-persistent database
 :database:
 
-# URL of the smart proxy, used for reporting back
-:callback_url: 'https://localhost:8443'
+# URL of the foreman, used for reporting back
+:foreman_url: 'http://localhost:3000'
+
+# SSL settings for client authentication against Foreman
+# :foreman_ssl_ca: ssl/foreman_ca.pem
+# :foreman_ssl_key: ssl/foreman_key.pem
+# :foreman_ssl_cert: ssl/foreman_cert.pem
+
+:console_auth: false
 
 # Set to true to make the core fork to background after start
 # :daemonize: false
@@ -15,7 +22,7 @@
 # Listen on port
 :port: 8008
 
-# SSL settings for client authentication against smart proxy.
+# SSL settings for running core as https service
 # :use_https: false
 # :ssl_ca_file: ssl/ca.pem
 # :ssl_private_key: ssl/localhost.pem
@@ -26,4 +33,3 @@
 
 # Log level, one of UNKNOWN, FATAL, ERROR, WARN, INFO, DEBUG
 # :log_level: ERROR
-

--- a/lib/smart_proxy_dynflow/api.rb
+++ b/lib/smart_proxy_dynflow/api.rb
@@ -16,13 +16,6 @@ module Proxy
         content_type :json
       end
 
-      post "/tasks/callback" do
-        response = Proxy::Dynflow::Callback::Request.send_to_foreman_tasks(request.body.read)
-        logger.info "Callback to foreman #{response.code} - #{response}"
-        status response.code
-        body response.body
-      end
-
       post "/*" do
         relay_request
       end

--- a/lib/smart_proxy_dynflow/callback.rb
+++ b/lib/smart_proxy_dynflow/callback.rb
@@ -3,20 +3,6 @@ require 'proxy/request'
 module Proxy
   class Dynflow
     module Callback
-      class Request < Proxy::HttpRequest::ForemanRequest
-        def callback(payload)
-          response = send_request(request_factory.create_post('foreman_tasks/api/tasks/callback', payload))
-          if response.code != "200"
-            raise "Failed performing callback to Foreman server: #{response.code} #{response.body}"
-          end
-          response
-        end
-
-        def self.send_to_foreman_tasks(payload)
-          self.new.callback(payload)
-        end
-      end
-
       class Core < Proxy::HttpRequest::ForemanRequest
         def uri
           @uri ||= URI.parse Proxy::Dynflow::Plugin.settings.core_url

--- a/lib/smart_proxy_dynflow/plugin.rb
+++ b/lib/smart_proxy_dynflow/plugin.rb
@@ -14,7 +14,6 @@ class Proxy::Dynflow
     https_rackup_path File.expand_path(rackup_path, File.expand_path("../", __FILE__))
 
     settings_file "dynflow.yml"
-    default_settings :console_auth => true
     default_settings :core_url => 'http://localhost:8008'
     plugin :dynflow, Proxy::Dynflow::VERSION
   end

--- a/lib/smart_proxy_dynflow_core/helpers.rb
+++ b/lib/smart_proxy_dynflow_core/helpers.rb
@@ -10,6 +10,13 @@ module SmartProxyDynflowCore
           status 403
           Log.instance.error "No client SSL certificate supplied"
           halt MultiJson.dump(:error => "No client SSL certificate supplied")
+        else
+          client_cert = OpenSSL::X509::Certificate.new(request.env['SSL_CLIENT_CERT'])
+          unless SmartProxyDynflowCore::Core.instance.accepted_cert_serial == client_cert.serial
+            Log.instance.error "SSL certificate with unexpected serial supplied"
+            halt MultiJson.dump(:error => "SSL certificate with unexpected serial supplied")
+            status 403
+          end
         end
       else
         Log.instance.debug 'require_ssl_client_verification: skipping, non-HTTPS request'

--- a/lib/smart_proxy_dynflow_core/settings.rb
+++ b/lib/smart_proxy_dynflow_core/settings.rb
@@ -22,15 +22,17 @@ module SmartProxyDynflowCore
 
     DEFAULT_SETTINGS = {
         :database => '/var/lib/foreman-proxy/dynflow/dynflow.sqlite',
-        :callback_url => 'https://127.0.0.1:8443',
+        :foreman_url => 'https://127.0.0.1:3000',
         :console_auth => true,
-        :foreman_url => 'http://127.0.0.1:3000',
         :listen => '127.0.0.1',
         :port => '8008',
         :use_https => false,
         :ssl_ca_file => nil,
         :ssl_private_key => nil,
         :ssl_certificate => nil,
+        :foreman_ssl_ca => nil,
+        :foreman_ssl_key => nil,
+        :foreman_ssl_cert => nil,
         :standalone => false,
         :log_file => '/var/log/foreman-proxy/smart_proxy_dynflow_core.log',
         :log_level => :ERROR,
@@ -40,7 +42,8 @@ module SmartProxyDynflowCore
         :loaded => false
     }
 
-    PROXY_SETTINGS = [:ssl_certificate, :ssl_ca_file, :ssl_private_key, :foreman_url,
+    PROXY_SETTINGS = [:ssl_ca_file, :ssl_certificate, :ssl_private_key, :foreman_url,
+                      :foreman_ssl_ca, :foreman_ssl_cert, :foreman_ssl_key,
                       :log_file, :log_level]
     PLUGIN_SETTINGS = [:database, :core_url, :console_auth]
 
@@ -70,7 +73,6 @@ module SmartProxyDynflowCore
       PROXY_SETTINGS.each do |key|
         SETTINGS[key] = Proxy::SETTINGS[key]
       end
-      SETTINGS.callback_url = SETTINGS.foreman_url
       PLUGIN_SETTINGS.each do |key|
         SETTINGS[key] = plugin.settings[key]
       end

--- a/settings.d/dynflow.yml.example
+++ b/settings.d/dynflow.yml.example
@@ -1,5 +1,4 @@
 ---
 :enabled: true
 :database: /var/lib/foreman-proxy/dynflow/dynflow.sqlite
-:console_auth: true
 :core_url: 'http://127.0.0.1:8008'

--- a/test/api_test/api_test.rb
+++ b/test/api_test/api_test.rb
@@ -43,12 +43,5 @@ class Proxy::Dynflow
       post '/tasks/12345/cancel', {}
     end
 
-    it 'relays callbacks' do
-      data = '{"callback": "callback", "data": "data"}'
-      Proxy::Dynflow::Callback::Request.expects(:send_to_foreman_tasks).with(data)
-                                       .returns(OpenStruct.new(:code => 200, :body => data))
-      post '/tasks/callback', data
-    end
-
   end
 end

--- a/test/api_test/test_helper.rb
+++ b/test/api_test/test_helper.rb
@@ -9,5 +9,7 @@ require 'smart_proxy_for_testing'
 
 require 'smart_proxy_dynflow'
 
+Proxy::Dynflow::Plugin.load_test_settings({})
+
 logdir = File.join(File.dirname(__FILE__), '..', '..', 'logs')
 FileUtils.mkdir_p(logdir) unless File.exist?(logdir)


### PR DESCRIPTION
They might differ form the certs used for https.

Also, we now detect the need for certs based on the schema of the callback url.

I've updated the settings.yml.example to start with http by default, for
development purposes, not expecting the devels to have the certs in place.

The certs part in setting file I used when testing with Katello
looked something like this:

```
:ssl_ca_file:  /etc/foreman-proxy/ssl_ca.pem
:ssl_private_key: /etc/foreman-proxy/ssl_key.pem
:ssl_certificate: /etc/foreman-proxy/ssl_cert.pem

:foreman_ssl_ca:  /etc/foreman-proxy/foreman_ssl_ca.pem
:foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
:foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
```