### PR TITLE
Refs #16058 - integrate foreman-tasks-core

### DIFF
--- a/lib/smart_proxy_dynflow/plugin.rb
+++ b/lib/smart_proxy_dynflow/plugin.rb
@@ -17,5 +17,14 @@ class Proxy::Dynflow
     requires :foreman_proxy, ">= 1.12.0"
     default_settings :core_url => 'http://localhost:8008'
     plugin :dynflow, Proxy::Dynflow::VERSION
+
+    after_activation do
+      begin
+        require 'smart_proxy_dynflow_core'
+      rescue LoadError => e
+        # Dynflow core is not available in the proxy, will be handled
+        # by standalone Dynflow core
+      end
+    end
   end
 end

--- a/lib/smart_proxy_dynflow_core.rb
+++ b/lib/smart_proxy_dynflow_core.rb
@@ -1,6 +1,12 @@
+require 'dynflow'
+require 'foreman_tasks_core'
 require 'smart_proxy_dynflow_core/log'
 require 'smart_proxy_dynflow_core/settings'
 require 'smart_proxy_dynflow_core/core'
 require 'smart_proxy_dynflow_core/helpers'
 require 'smart_proxy_dynflow_core/callback'
 require 'smart_proxy_dynflow_core/api'
+
+SmartProxyDynflowCore::Core.after_initialize do |dynflow_core|
+  ForemanTasksCore.dynflow_setup(dynflow_core.world)
+end

--- a/lib/smart_proxy_dynflow_core/api.rb
+++ b/lib/smart_proxy_dynflow_core/api.rb
@@ -1,6 +1,5 @@
 require 'sinatra/base'
 require 'multi_json'
-require 'dynflow'
 
 module SmartProxyDynflowCore
   class Api < ::Sinatra::Base

--- a/lib/smart_proxy_dynflow_core/callback.rb
+++ b/lib/smart_proxy_dynflow_core/callback.rb
@@ -1,5 +1,4 @@
 require 'rest-client'
-require 'dynflow'
 
 begin
   require 'smart_proxy_dynflow/callback'
@@ -8,6 +7,16 @@ end
 
 module SmartProxyDynflowCore
   module Callback
+    class Action < Dynflow::Action
+      def plan(callback, data)
+        plan_self(:callback => callback, :data => data)
+      end
+
+      def run
+        Request.send_to_foreman_tasks(input[:callback], input[:data])
+      end
+    end
+
     class Request
       def callback(payload)
         response = callback_resource.post(payload, :content_type => :json)

--- a/lib/smart_proxy_dynflow_core/core.rb
+++ b/lib/smart_proxy_dynflow_core/core.rb
@@ -60,7 +60,7 @@ module SmartProxyDynflowCore
       def ensure_initialized
         return @instance if @instance
         @instance = Core.new
-        after_initialize_blocks.each(&:call)
+        after_initialize_blocks.each { |block| block.call(@instance) }
         @instance
       end
 

--- a/lib/smart_proxy_dynflow_core/launcher.rb
+++ b/lib/smart_proxy_dynflow_core/launcher.rb
@@ -117,6 +117,16 @@ module SmartProxyDynflowCore
         Dir[File.join(dir, 'settings.d', '*.yml')].each { |path| Settings.load_plugin_settings(path) }
         true
       end
+      ForemanTasksCore::SettingsLoader.settings_registry.keys.each do |settings_keys|
+        settings = settings_keys.inject({}) do |h, settings_key|
+          if SETTINGS.plugins.key?(settings_key.to_s)
+            h.merge(SETTINGS.plugins[settings_key.to_s].to_h)
+          else
+            h
+          end
+        end
+        ForemanTasksCore::SettingsLoader.setup_settings(settings_keys.first, settings)
+      end
     end
   end
 end

--- a/lib/smart_proxy_dynflow_core/log.rb
+++ b/lib/smart_proxy_dynflow_core/log.rb
@@ -1,5 +1,4 @@
 require 'logger'
-require 'dynflow'
 
 module SmartProxyDynflowCore
   class Log < ::Logger

--- a/lib/smart_proxy_dynflow_core/settings.rb
+++ b/lib/smart_proxy_dynflow_core/settings.rb
@@ -69,12 +69,13 @@ module SmartProxyDynflowCore
       Log.reload!
     end
 
-    def self.load_from_proxy(settings)
+    def self.load_from_proxy(plugin)
+      settings = plugin[:class].settings.to_h
       PROXY_SETTINGS.each do |key|
         SETTINGS[key] = Proxy::SETTINGS[key]
       end
       PLUGIN_SETTINGS.each do |key|
-        SETTINGS[key] = settings[key]
+        SETTINGS[key] = settings[key] if settings.key?(key)
       end
       SETTINGS.plugins.values.each { |plugin| plugin.load_settings_from_proxy }
       Settings.loaded!

--- a/smart_proxy_dynflow_core.gemspec
+++ b/smart_proxy_dynflow_core.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rack-test', '~> 0')
   gem.add_development_dependency('rubocop', '0.32.1')
 
+  gem.add_runtime_dependency('foreman-tasks-core', '~> 0.1.0')
   gem.add_runtime_dependency('dynflow', "~> 0.8.4")
   gem.add_runtime_dependency('sequel')
   gem.add_runtime_dependency('sqlite3')


### PR DESCRIPTION
This allows any gem using foreman-tasks-core to use both foreman and
smart proxy as the process for running it