### PR TITLE
Fixes #20892 - better waiting for required state

### DIFF
--- a/test/core_test/api_test.rb
+++ b/test/core_test/api_test.rb
@@ -52,8 +52,7 @@ module SmartProxyDynflowCore
     describe 'POST /tasks/:task_id/cancel' do
       it 'cancels the action' do
         triggered = WORLD.trigger(StuckAction)
-        wait_until { WORLD.persistence.load_execution_plan(triggered.id).state == :running }
-
+        wait_until { WORLD.persistence.load_execution_plan(triggered.id).cancellable? }
         post "/tasks/#{triggered.id}/cancel"
         triggered.finished.wait(5)
 


### PR DESCRIPTION
It seems the `triggered.finished` finishes sooner than the persistence
is updated. Adding `wait_for` to check the state instead.