### PR TITLE
Fixes #22141 - Remove sinatra/rack dependencies

### DIFF
--- a/smart_proxy_dynflow_core.gemspec
+++ b/smart_proxy_dynflow_core.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('foreman-tasks-core', '>= 0.1.7')
   gem.add_runtime_dependency('sequel')
   gem.add_runtime_dependency('sqlite3')
-  gem.add_runtime_dependency('sinatra', '~> 1.4')
+  gem.add_runtime_dependency('sinatra')
   gem.add_runtime_dependency('rack')
   gem.add_runtime_dependency('rest-client')
 end


### PR DESCRIPTION
Without this, I'm getting the following error when running `bundle update` on smart-proxy (develop branch). I suppose the plugin can simply rely on sinatra/rack being provided by smart-proxy.

```
Resolving dependencies......
Bundler could not find compatible versions for gem "rack-protection":
  In Gemfile:
    smart_proxy was resolved to 1.17.0.develop, which depends on
      sinatra was resolved to 1.4.6, which depends on
        rack-protection (= 2.0.0)

    smart_proxy_dynflow_core was resolved to 0.1.8, which depends on
      sinatra (~> 1.4) was resolved to 1.4.6, which depends on
        rack-protection (~> 1.4)
Bundler could not find compatible versions for gem "tilt":
  In Gemfile:
    smart_proxy was resolved to 1.17.0.develop, which depends on
      sinatra was resolved to 1.4.0, which depends on
        tilt (~> 2.0)

    smart_proxy_dynflow_core was resolved to 0.1.8, which depends on
      sinatra (~> 1.4) was resolved to 1.4.0, which depends on
        tilt (>= 1.3.4, ~> 1.3)
```