### PR TITLE
Fixes #26374 - use proxy code for authorization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,7 +86,7 @@ Style/Next:
   Enabled: false
 
 Metrics/AbcSize:
-  Max: 30
+  Enabled: false
 
 Metrics/CyclomaticComplexity:
   Max: 15

--- a/lib/smart_proxy_dynflow/api.rb
+++ b/lib/smart_proxy_dynflow/api.rb
@@ -15,42 +15,7 @@ module Proxy
           # Halt running before callbacks if a token is provided and the request is notifying about task being done
           return
         else
-          do_authorize_with_ssl_client
-          do_authorize_with_trusted_hosts
-        end
-      end
-
-      # TODO: move this to foreman-proxy to reduce code duplicities
-      def do_authorize_with_trusted_hosts
-        # When :trusted_hosts is given, we check the client against the list
-        # HTTPS: test the certificate CN
-        # HTTP: test the reverse DNS entry of the remote IP
-        trusted_hosts = Proxy::SETTINGS.trusted_hosts
-        if trusted_hosts
-          if ['yes', 'on', 1].include? request.env['HTTPS'].to_s
-            fqdn = https_cert_cn
-            source = 'SSL_CLIENT_CERT'
-          else
-            fqdn = remote_fqdn(Proxy::SETTINGS.forward_verify)
-            source = 'REMOTE_ADDR'
-          end
-          fqdn = fqdn.downcase
-          logger.debug "verifying remote client #{fqdn} (based on #{source}) against trusted_hosts #{trusted_hosts}"
-
-          unless Proxy::SETTINGS.trusted_hosts.include?(fqdn)
-            log_halt 403, "Untrusted client #{fqdn} attempted " \
-                          "to access #{request.path_info}. Check :trusted_hosts: in settings.yml"
-          end
-        end
-      end
-
-      def do_authorize_with_ssl_client
-        if %w[yes on 1].include? request.env['HTTPS'].to_s
-          if request.env['SSL_CLIENT_CERT'].to_s.empty?
-            log_halt 403, "No client SSL certificate supplied"
-          end
-        else
-          logger.debug('require_ssl_client_verification: skipping, non-HTTPS request')
+          do_authorize_any
         end
       end
 

--- a/lib/smart_proxy_dynflow/plugin.rb
+++ b/lib/smart_proxy_dynflow/plugin.rb
@@ -14,7 +14,7 @@ class Proxy::Dynflow
     https_rackup_path File.expand_path(rackup_path, File.expand_path("../", __FILE__))
 
     settings_file "dynflow.yml"
-    requires :foreman_proxy, ">= 1.12.0"
+    requires :foreman_proxy, ">= 1.22.0"
     default_settings :core_url => 'http://localhost:8008'
     plugin :dynflow, Proxy::Dynflow::VERSION
 

--- a/lib/smart_proxy_dynflow_core/helpers.rb
+++ b/lib/smart_proxy_dynflow_core/helpers.rb
@@ -21,7 +21,7 @@ module SmartProxyDynflowCore
     end
 
     def authorize_with_ssl_client
-      if %w[yes on 1].include? request.env['HTTPS'].to_s
+      if request.env['HTTPS']
         if request.env['SSL_CLIENT_CERT'].to_s.empty?
           Log.instance.error "No client SSL certificate supplied"
           halt 403, MultiJson.dump(:error => "No client SSL certificate supplied")
@@ -32,8 +32,10 @@ module SmartProxyDynflowCore
             halt 403, MultiJson.dump(:error => "SSL certificate with unexpected serial supplied")
           end
         end
-      else
+      elsif !Settings.instance.use_https
         Log.instance.debug 'require_ssl_client_verification: skipping, non-HTTPS request'
+      else
+        halt 403, MultiJson.dump(:error => "The client could not be authorized")
       end
     end
 

--- a/lib/smart_proxy_dynflow_core/webrick-patch.rb
+++ b/lib/smart_proxy_dynflow_core/webrick-patch.rb
@@ -7,7 +7,6 @@ CIPHERS = ['ECDHE-RSA-AES128-GCM-SHA256', 'ECDHE-RSA-AES256-GCM-SHA384',
 
 module WEBrick
   class GenericServer
-    # rubocop:disable Metrics/AbcSize
     def setup_ssl_context(config) # :nodoc:
       unless config[:SSLCertificate]
         cn = config[:SSLCertName]
@@ -34,6 +33,5 @@ module WEBrick
       ctx.options |= config[:SSLOptions] unless config[:SSLOptions].nil?
       ctx
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end


### PR DESCRIPTION
Also, I've made the core authorization code a bit more defensive:
I've noticed that Puma is setting 'https' in `ENV['HTTPS']`: if we don't
check that we should use https, we would be letting the requests though
even if we shouldn't. Luckily, we're not running Puma just yet, but it's
good to be prepared, so we're actually also checking whether we really
are not using https. Also, just the presence of `ENV['HTTPS']` is now
enough to assume we are in the SSL mode.