### PR TITLE
Fixes #26691 - add `POST /tasks/:task_id/update` endpoint

### DIFF
--- a/lib/smart_proxy_dynflow/api.rb
+++ b/lib/smart_proxy_dynflow/api.rb
@@ -11,7 +11,7 @@ module Proxy
 
       before do
         content_type :json
-        if request.env['HTTP_AUTHORIZATION'] && request.env['PATH_INFO'].end_with?('/done')
+        if request.env['HTTP_AUTHORIZATION'] && request.path_info =~  %r{/tasks/.*/(update|done)}
           # Halt running before callbacks if a token is provided and the request is notifying about task being done
           return
         else

--- a/lib/smart_proxy_dynflow/api.rb
+++ b/lib/smart_proxy_dynflow/api.rb
@@ -11,7 +11,7 @@ module Proxy
 
       before do
         content_type :json
-        if request.env['HTTP_AUTHORIZATION'] && request.path_info =~  %r{/tasks/.*/(update|done)}
+        if request.env['HTTP_AUTHORIZATION'] && request.path_info =~ %r{/tasks/.*/(update|done)}
           # Halt running before callbacks if a token is provided and the request is notifying about task being done
           return
         else

--- a/lib/smart_proxy_dynflow_core/api.rb
+++ b/lib/smart_proxy_dynflow_core/api.rb
@@ -51,12 +51,7 @@ module SmartProxyDynflowCore
       tasks_count(params['state']).to_json
     end
 
-    post "/tasks/:task_id/update" do |task_id|
-      data = MultiJson.load(request.body.read)
-      dispatch_external_event(task_id, data)
-    end
-
-    post "/tasks/:task_id/done" do |task_id|
+    post %r{/tasks/([\S]+)/(?:update|done)} do |task_id|
       data = MultiJson.load(request.body.read)
       dispatch_external_event(task_id, data)
     end

--- a/lib/smart_proxy_dynflow_core/api.rb
+++ b/lib/smart_proxy_dynflow_core/api.rb
@@ -8,7 +8,8 @@ module SmartProxyDynflowCore
 
     before do
       if match = request.path_info.match(TASK_UPDATE_REGEXP_PATH)
-        task_id, action = match[1], match[2]
+        task_id = match[1]
+        action = match[2]
         authorize_with_token(task_id: task_id, clear: action == 'done')
       else
         authorize_with_ssl_client

--- a/lib/smart_proxy_dynflow_core/helpers.rb
+++ b/lib/smart_proxy_dynflow_core/helpers.rb
@@ -4,13 +4,13 @@ module SmartProxyDynflowCore
       SmartProxyDynflowCore::Core.world
     end
 
-    def authorize_with_token(clear: true)
+    def authorize_with_token(task_id:, clear: true)
       if request.env.key? 'HTTP_AUTHORIZATION'
         if defined?(::ForemanTasksCore)
           auth = request.env['HTTP_AUTHORIZATION']
           basic_prefix = /\ABasic /
           if !auth.to_s.empty? && auth =~ basic_prefix &&
-             ForemanTasksCore::OtpManager.authenticate(auth.gsub(basic_prefix, ''), clear: clear)
+             ForemanTasksCore::OtpManager.authenticate(auth.gsub(basic_prefix, ''), expected_user: task_id, clear: clear)
             Log.instance.debug('authorized with token')
             return true
           end

--- a/lib/smart_proxy_dynflow_core/helpers.rb
+++ b/lib/smart_proxy_dynflow_core/helpers.rb
@@ -4,13 +4,13 @@ module SmartProxyDynflowCore
       SmartProxyDynflowCore::Core.world
     end
 
-    def authorize_with_token
+    def authorize_with_token(clear: true)
       if request.env.key? 'HTTP_AUTHORIZATION'
         if defined?(::ForemanTasksCore)
           auth = request.env['HTTP_AUTHORIZATION']
           basic_prefix = /\ABasic /
           if !auth.to_s.empty? && auth =~ basic_prefix &&
-             ForemanTasksCore::OtpManager.authenticate(auth.gsub(basic_prefix, ''))
+             ForemanTasksCore::OtpManager.authenticate(auth.gsub(basic_prefix, ''), clear: clear)
             Log.instance.debug('authorized with token')
             return true
           end
@@ -63,7 +63,7 @@ module SmartProxyDynflowCore
       { :count => tasks.count, :state => state }
     end
 
-    def complete_task(task_id, params)
+    def dispatch_external_event(task_id, params)
       world.event(task_id,
                   params['step_id'].to_i,
                   ::ForemanTasksCore::Runner::ExternalEvent.new(params))

--- a/lib/smart_proxy_dynflow_core/helpers.rb
+++ b/lib/smart_proxy_dynflow_core/helpers.rb
@@ -10,7 +10,8 @@ module SmartProxyDynflowCore
           auth = request.env['HTTP_AUTHORIZATION']
           basic_prefix = /\ABasic /
           if !auth.to_s.empty? && auth =~ basic_prefix &&
-             ForemanTasksCore::OtpManager.authenticate(auth.gsub(basic_prefix, ''), expected_user: task_id, clear: clear)
+             ForemanTasksCore::OtpManager.authenticate(auth.gsub(basic_prefix, ''),
+                                                       expected_user: task_id, clear: clear)
             Log.instance.debug('authorized with token')
             return true
           end

--- a/smart_proxy_dynflow_core.gemspec
+++ b/smart_proxy_dynflow_core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('webmock', '~> 1')
 
   gem.add_runtime_dependency('dynflow', "~> 1.1")
-  gem.add_runtime_dependency('foreman-tasks-core', '>= 0.1.7')
+  gem.add_runtime_dependency('foreman-tasks-core', '>= 0.3.3')
   gem.add_runtime_dependency('rack')
   gem.add_runtime_dependency('rest-client')
   gem.add_runtime_dependency('sequel')


### PR DESCRIPTION
Propagates external events to underlying action without invalidating the
OTP, so that it can be called multiple times.

Depends on:

- [x] - https://github.com/theforeman/foreman-tasks/pull/416