### PR TITLE
Fixes #26969 - Allow using remote core even if core gem is available

### DIFF
--- a/lib/smart_proxy_dynflow/http_config.ru
+++ b/lib/smart_proxy_dynflow/http_config.ru
@@ -1,15 +1,7 @@
 # Internal core will be used if external core is either disabled or unset
 # and the core gem can be loaded
-internal_core = unless Proxy::Dynflow::Plugin.settings.external_core
-                  begin
-                    require 'smart_proxy_dynflow_core'
-                    true
-                  rescue LoadError
-                    false
-                  end
-                end
 
-if internal_core
+if !::Proxy::Dynflow::Plugin.settings.external_core && Proxy::Dynflow::Plugin.internal_core_available?
   require 'smart_proxy_dynflow_core/api'
   require 'smart_proxy_dynflow_core/launcher'
 

--- a/lib/smart_proxy_dynflow/http_config.ru
+++ b/lib/smart_proxy_dynflow/http_config.ru
@@ -1,7 +1,29 @@
-require 'smart_proxy_dynflow/api'
+# Internal core will be used if external core is either disabled or unset
+# and the core gem can be loaded
+internal_core = unless Proxy::Dynflow::Plugin.settings.external_core
+                  begin
+                    require 'smart_proxy_dynflow_core'
+                    true
+                  rescue LoadError
+                    false
+                  end
+                end
 
-map "/dynflow" do
-  map '/' do
-    run Proxy::Dynflow::Api
+if internal_core
+  require 'smart_proxy_dynflow_core/api'
+  require 'smart_proxy_dynflow_core/launcher'
+
+  SmartProxyDynflowCore::Settings.load_from_proxy(p)
+
+  map "/dynflow" do
+    SmartProxyDynflowCore::Launcher.route_mapping(self)
+  end
+else
+  require 'smart_proxy_dynflow/api'
+
+  map "/dynflow" do
+    map '/' do
+      run Proxy::Dynflow::Api
+    end
   end
 end

--- a/lib/smart_proxy_dynflow/http_config_with_executor.ru
+++ b/lib/smart_proxy_dynflow/http_config_with_executor.ru
@@ -1,8 +1,0 @@
-require 'smart_proxy_dynflow_core/api'
-require 'smart_proxy_dynflow_core/launcher'
-
-SmartProxyDynflowCore::Settings.load_from_proxy(p)
-
-map "/dynflow" do
-  SmartProxyDynflowCore::Launcher.route_mapping(self)
-end

--- a/lib/smart_proxy_dynflow/plugin.rb
+++ b/lib/smart_proxy_dynflow/plugin.rb
@@ -4,7 +4,7 @@ require 'proxy/plugin'
 
 class Proxy::Dynflow
   class Plugin < Proxy::Plugin
-    rackup_path = File.expand_path('http_config.ru', File.expand_path("../", __FILE__))
+    rackup_path = File.expand_path('http_config.ru', __dir__)
     http_rackup_path rackup_path
     https_rackup_path rackup_path
 

--- a/lib/smart_proxy_dynflow/plugin.rb
+++ b/lib/smart_proxy_dynflow/plugin.rb
@@ -4,29 +4,18 @@ require 'proxy/plugin'
 
 class Proxy::Dynflow
   class Plugin < Proxy::Plugin
-    rackup_path = begin
-      require 'smart_proxy_dynflow_core'
-      'http_config_with_executor.ru'
-    rescue LoadError
-      'http_config.ru'
-    end
-    http_rackup_path File.expand_path(rackup_path, File.expand_path("../", __FILE__))
-    https_rackup_path File.expand_path(rackup_path, File.expand_path("../", __FILE__))
+    rackup_path = File.expand_path('http_config.ru', File.expand_path("../", __FILE__))
+    http_rackup_path rackup_path
+    https_rackup_path rackup_path
 
     settings_file "dynflow.yml"
     requires :foreman_proxy, ">= 1.12.0"
     default_settings :core_url => 'http://localhost:8008'
     plugin :dynflow, Proxy::Dynflow::VERSION
 
-    # rubocop:disable Lint/HandleExceptions
     after_activation do
-      begin
-        require 'smart_proxy_dynflow_core'
-      rescue LoadError
-        # Dynflow core is not available in the proxy, will be handled
-        # by standalone Dynflow core
-      end
+      # Ensure the core gem is loaded, if configure NOT to use the external core
+      require 'smart_proxy_dynflow_core' if Proxy::Dynflow::Plugin.settings.external_core == false
     end
-    # rubocop:enable Lint/HandleExceptions
   end
 end

--- a/lib/smart_proxy_dynflow/plugin.rb
+++ b/lib/smart_proxy_dynflow/plugin.rb
@@ -15,7 +15,17 @@ class Proxy::Dynflow
 
     after_activation do
       # Ensure the core gem is loaded, if configure NOT to use the external core
-      require 'smart_proxy_dynflow_core' if Proxy::Dynflow::Plugin.settings.external_core == false
+      if Proxy::Dynflow::Plugin.settings.external_core == false && !internal_core_available?
+        raise "'smart_proxy_dynflow_core' gem is required, but not available"
+      end
+    end
+
+    def self.internal_core_available?
+      @core_available ||= begin
+                            require 'smart_proxy_dynflow_core'
+                            true
+                          rescue LoadError
+                          end
     end
   end
 end

--- a/lib/smart_proxy_dynflow/plugin.rb
+++ b/lib/smart_proxy_dynflow/plugin.rb
@@ -24,7 +24,7 @@ class Proxy::Dynflow
       @core_available ||= begin
                             require 'smart_proxy_dynflow_core'
                             true
-                          rescue LoadError
+                          rescue LoadError # rubocop:disable Lint/HandleExceptions
                           end
     end
   end

--- a/settings.d/dynflow.yml.example
+++ b/settings.d/dynflow.yml.example
@@ -2,3 +2,8 @@
 :enabled: true
 :database: /var/lib/foreman-proxy/dynflow/dynflow.sqlite
 :core_url: 'http://127.0.0.1:8008'
+
+# If true, external core will be used even if the core gem is available
+# If false, the feature will be disabled if the core gem is not available
+# If unset, the process will fallback to external core if the core gem is not available
+# :external_core: true


### PR DESCRIPTION
The behavior can be configured using the `external_core` key in the settings.

If unset, the behavior will remain the same, eg. use internal core if available,
fallback to external core otherwise. Setting it to `true` will force the proxy to
always use an external core. Setting it to `false` will make the proxy try to
always use the internal core and disable the feature if it is not available.