### PR TITLE
Fixes #29624 - Stop accepting TLS 1.1

### DIFF
--- a/lib/smart_proxy_dynflow_core/launcher.rb
+++ b/lib/smart_proxy_dynflow_core/launcher.rb
@@ -93,6 +93,7 @@ module SmartProxyDynflowCore
       ssl_options |= OpenSSL::SSL::OP_NO_SSLv2 if defined?(OpenSSL::SSL::OP_NO_SSLv2)
       ssl_options |= OpenSSL::SSL::OP_NO_SSLv3 if defined?(OpenSSL::SSL::OP_NO_SSLv3)
       ssl_options |= OpenSSL::SSL::OP_NO_TLSv1 if defined?(OpenSSL::SSL::OP_NO_TLSv1)
+      ssl_options |= OpenSSL::SSL::OP_NO_TLSv1_1 if defined?(OpenSSL::SSL::OP_NO_TLSv1_1)
 
       if Settings.instance.tls_disabled_versions
         Settings.instance.tls_disabled_versions.each do |version|


### PR DESCRIPTION
Current setups shouldn't use TLS 1.1 anymore. PCI compliant setups are also required to disable it. By doing this out of the box, the software becomes more secure and more compliant.