### PR TITLE
Fixes #30278 - Fix missing newlines in logs

### DIFF
--- a/lib/smart_proxy_dynflow_core/log.rb
+++ b/lib/smart_proxy_dynflow_core/log.rb
@@ -77,7 +77,6 @@ module SmartProxyDynflowCore
       def initialize(logger, level = Logger::DEBUG, _formatters = [])
         @logger           = logger
         @logger.level     = level
-        @logger.formatter = ProxyStructuredFormater.new(@logger)
         @action_logger    = apply_formatters(ProgNameWrapper.new(@logger, ' action'), [ProxyStructuredFormater])
         @dynflow_logger   = apply_formatters(ProgNameWrapper.new(@logger, 'dynflow'), [ProxyStructuredFormater])
       end


### PR DESCRIPTION
Before:
```
$ exec bin/smart_proxy_dynflow_core
D, [2020-07-01T15:18:18.451524 #2415322] DEBUG -- : Using HTTP
I, [2020-07-01T15:18:18.455993 #2415322]  INFO -- : WEBrick 1.4.2
I, [2020-07-01T15:18:18.456018 #2415322]  INFO -- : ruby 2.6.3 (2019-04-16) [x86_64-linux]
D, [2020-07-01T15:18:18.456826 #2415322] DEBUG -- : Rack::Handler::WEBrick is mounted on /.
Could not open DB for dynflow at '', will keep data in memory. Restart will drop all dynflow data.Execution plan cleaner removing 0 execution plans.WEBrick::HTTPServer#start: pid=2415322 port=8008accept: 127.0.0.1:42150Rack::Handler::WEBrick is invoked.require_ssl_client_verification: skipping, non-HTTPS request127.0.0.1 - - [01/Jul/2020:15:18:23 CEST] "GET /task/count? HTTP/1.1" 404 528
close: 127.0.0.1:42150Executor heartbeatExecutor heartbeat^Cclose TCPSocket(::1, 8008)close TCPSocket(127.0.0.1, 8008)going to shutdown ...WEBrick::HTTPServer#start done.start terminating delayed_executor...start terminating throttle_limiter...start terminating executor...shutting down Core ...... Dynflow core terminated.start terminating executor dispatcher...start terminating client dispatcher...stop listening for new events...start terminating clock...%
```

After:
```
$ bundle exec bin/smart_proxy_dynflow_core
D, [2020-07-01T15:19:24.634248 #2415917] DEBUG -- : Using HTTP
I, [2020-07-01T15:19:24.638637 #2415917]  INFO -- : WEBrick 1.4.2
I, [2020-07-01T15:19:24.638665 #2415917]  INFO -- : ruby 2.6.3 (2019-04-16) [x86_64-linux]
D, [2020-07-01T15:19:24.639419 #2415917] DEBUG -- : Rack::Handler::WEBrick is mounted on /.
W, [2020-07-01T15:19:24.639492 #2415917]  WARN -- : Could not open DB for dynflow at '', will keep data in memory. Restart will drop all dynflow data.
I, [2020-07-01T15:19:24.684245 #2415917]  INFO -- dynflow: Execution plan cleaner removing 0 execution plans.
I, [2020-07-01T15:19:24.685436 #2415917]  INFO -- : WEBrick::HTTPServer#start: pid=2415917 port=8008
D, [2020-07-01T15:19:39.669295 #2415917] DEBUG -- dynflow: Executor heartbeat
D, [2020-07-01T15:19:54.672196 #2415917] DEBUG -- dynflow: Executor heartbeat
^CD, [2020-07-01T15:19:55.543972 #2415917] DEBUG -- : close TCPSocket(::1, 8008)
D, [2020-07-01T15:19:55.544132 #2415917] DEBUG -- : close TCPSocket(127.0.0.1, 8008)
I, [2020-07-01T15:19:55.544203 #2415917]  INFO -- : going to shutdown ...
I, [2020-07-01T15:19:55.544257 #2415917]  INFO -- : WEBrick::HTTPServer#start done.
I, [2020-07-01T15:19:55.545164 #2415917]  INFO -- dynflow: start terminating delayed_executor...
I, [2020-07-01T15:19:55.548561 #2415917]  INFO -- dynflow: start terminating throttle_limiter...
I, [2020-07-01T15:19:55.552315 #2415917]  INFO -- dynflow: start terminating executor...
I, [2020-07-01T15:19:55.552849 #2415917]  INFO -- dynflow: shutting down Core ...
I, [2020-07-01T15:19:55.565278 #2415917]  INFO -- dynflow: ... Dynflow core terminated.
I, [2020-07-01T15:19:55.566380 #2415917]  INFO -- dynflow: start terminating executor dispatcher...
I, [2020-07-01T15:19:55.573431 #2415917]  INFO -- dynflow: start terminating client dispatcher...
I, [2020-07-01T15:19:55.577786 #2415917]  INFO -- dynflow: stop listening for new events...
I, [2020-07-01T15:19:55.579523 #2415917]  INFO -- dynflow: start terminating clock...
```

This is just a temporary workaround until https://github.com/theforeman/smart_proxy_dynflow/pull/61 gets in