### PR TITLE
Fix logging argument for Ruby 2.7

### DIFF
--- a/lib/smart_proxy_dynflow_core/log.rb
+++ b/lib/smart_proxy_dynflow_core/log.rb
@@ -43,7 +43,7 @@ module SmartProxyDynflowCore
       @file = file
       @fd = @file.is_a?(IO) ? @file : File.open(@file, 'a')
       @fd.sync = true
-      super(@fd, rest)
+      super(@fd, *rest)
     end
 
     def roll_log


### PR DESCRIPTION
Automatic conversion was deprecated:

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

This was giving: https://gist.github.com/lzap/24e0a7e10bcc45c9250e5a588f849b48

on Ruby 2.7+