### PR TITLE
Don't crash on plugin without a setting

### DIFF
--- a/lib/smart_proxy_dynflow_core/settings.rb
+++ b/lib/smart_proxy_dynflow_core/settings.rb
@@ -94,7 +94,7 @@ module SmartProxyDynflowCore
       settings = YAML.load_file(path)
       name = File.basename(path).gsub(/\.yml$/, '')
       if SETTINGS.plugins.key? name
-        settings = SETTINGS.plugins[name].to_h.merge(settings)
+        settings = SETTINGS.plugins[name].to_h.merge(settings || {})
       end
       SETTINGS.plugins[name] = OpenStruct.new settings
     end


### PR DESCRIPTION
I've encountered the following issue when a plugin setting was nil

```
Traceback (most recent call last):
12: from /usr/bin/smart_proxy_dynflow_core:23:in `<main>'
11: from /usr/bin/smart_proxy_dynflow_core:23:in `load'
10: from /opt/theforeman/tfm/root/usr/share/gems/gems/smart_proxy_dynflow_core-0.2.6/bin/smart_proxy_dynflow_core:32:in `<top (required)>'
 9: from /opt/theforeman/tfm/root/usr/share/gems/gems/smart_proxy_dynflow_core-0.2.6/lib/smart_proxy_dynflow_core/launcher.rb:13:in `launch!'
 8: from /opt/theforeman/tfm/root/usr/share/gems/gems/smart_proxy_dynflow_core-0.2.6/lib/smart_proxy_dynflow_core/launcher.rb:17:in `start'
 7: from /opt/theforeman/tfm/root/usr/share/gems/gems/smart_proxy_dynflow_core-0.2.6/lib/smart_proxy_dynflow_core/launcher.rb:36:in `load_settings!'
 6: from /opt/theforeman/tfm/root/usr/share/gems/gems/smart_proxy_dynflow_core-0.2.6/lib/smart_proxy_dynflow_core/launcher.rb:36:in `each'
 5: from /opt/theforeman/tfm/root/usr/share/gems/gems/smart_proxy_dynflow_core-0.2.6/lib/smart_proxy_dynflow_core/launcher.rb:37:in `block in load_settings!'
 4: from /opt/theforeman/tfm/root/usr/share/gems/gems/smart_proxy_dynflow_core-0.2.6/lib/smart_proxy_dynflow_core/launcher.rb:152:in `load_config_dir'
 3: from /opt/theforeman/tfm/root/usr/share/gems/gems/smart_proxy_dynflow_core-0.2.6/lib/smart_proxy_dynflow_core/launcher.rb:152:in `each'
 2: from /opt/theforeman/tfm/root/usr/share/gems/gems/smart_proxy_dynflow_core-0.2.6/lib/smart_proxy_dynflow_core/launcher.rb:152:in `block in load_config_dir'
 1: from /opt/theforeman/tfm/root/usr/share/gems/gems/smart_proxy_dynflow_core-0.2.6/lib/smart_proxy_dynflow_core/settings.rb:97:in `load_plugin_settings'
/opt/theforeman/tfm/root/usr/share/gems/gems/smart_proxy_dynflow_core-0.2.6/lib/smart_proxy_dynflow_core/settings.rb:97:in `merge': no implicit conversion of nil into Hash (TypeError)
```