### PR TITLE
Fixes #31352 - separate journald bundler group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ group :test do
   gem 'rubocop', '~> 0.52.1'
 end
 
-gem 'logging-journald', '~> 2.0', :platforms => [:ruby]
 gem 'rack', '>= 1.1'
 gem 'sinatra'
 

--- a/bundler.d/journald.rb
+++ b/bundler.d/journald.rb
@@ -1,0 +1,6 @@
+# Disable to avoid journald native gem in development setup.
+# This group is only distributed in dynflow_core (not needed
+# for smart-proxy plugins as logging is provided by smart-proxy).
+group :journald do
+  gem 'logging-journald', '~> 2.0', :platforms => [:ruby]
+end

--- a/smart_proxy_dynflow_core.gemspec
+++ b/smart_proxy_dynflow_core.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
 
   gem.executables   = ['smart_proxy_dynflow_core']
   gem.files         = Dir['lib/smart_proxy_dynflow_core.rb', 'config/settings.yml.example',
-                          'lib/smart_proxy_dynflow_core/**/*', 'LICENSE', 'Gemfile',
+                          'lib/smart_proxy_dynflow_core/**/*', 'LICENSE', 'Gemfile', 'bundler.d/*.rb',
                           'bin/smart_proxy_dynflow_core', 'deploy/*', 'smart_proxy_dynflow_core.gemspec']
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]


### PR DESCRIPTION
We must not require logging-journald by default, users should be able to run without it in development or on production platforms which don't have journald. After this is separated, we need to add a metapackage similarly as smart proxy and also modify our installer to install it if journal logging is enabled (or if thats not configurable then always install it):

```
%package journald
Summary:  Foreman Proxy journald logging dependencies
Group:    Applications/System
Requires: %{?scl_prefix}rubygem(logging-journald) >= 2.0
Requires: %{?scl_prefix}rubygem(logging-journald) < 3.0
Requires: %{name} = %{version}-%{release}

%description journald
Additional dependencies required to configure journald logging.

%files journald
%{_datadir}/%{name}/bundler.d/journald.rb
```