### PR TITLE
Fixes #31352 - don't require logging-journald

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'rubocop', '~> 0.52.1'
 end
 
-gem 'logging-journald', '~> 2.0', :platforms => [:ruby]
+gem 'logging-journald', '~> 2.0', :platforms => [:ruby], :require => false
 gem 'rack', '>= 1.1'
 gem 'sinatra'
 


### PR DESCRIPTION
Solves the issue mentioned in the ticket. The logging gem uses auto loading capability and discovers all plugins automatically, there is no need to require it.

However if uses configures journald he/she must ensure the gem was installed otherwise it will error out.