### PR TITLE
Refs #32534 - add forgotten deps from dynflow_core

### DIFF
--- a/smart_proxy_dynflow.gemspec
+++ b/smart_proxy_dynflow.gemspec
@@ -21,7 +21,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '~> 2.5'
 
-  gem.add_runtime_dependency "logging"
+  gem.add_runtime_dependency('dynflow', "~> 1.1")
+  gem.add_runtime_dependency('rest-client')
+  gem.add_runtime_dependency('sqlite3')
 
   gem.add_development_dependency "bundler", ">= 1.7"
   gem.add_development_dependency 'minitest'


### PR DESCRIPTION
In e205e19a00d8ef269953811a3c4e5140776915b1 we've removed the dependency
on smart_proxy_dynflow_core, but we've forgotten to bring over the gem
runtime dependencies.