### PR TITLE
Require smart_proxy_dynflow by smart_proxy_dynflow_core

### DIFF
--- a/smart_proxy_dynflow_core.gemspec
+++ b/smart_proxy_dynflow_core.gemspec
@@ -36,5 +36,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('sd_notify', '~> 0.1')
   gem.add_runtime_dependency('sequel')
   gem.add_runtime_dependency('sinatra')
+  gem.add_runtime_dependency('smart_proxy_dynflow')
   gem.add_runtime_dependency('sqlite3')
 end


### PR DESCRIPTION
@adamruzicka I doubt this is the correct solution but it helps me illustrate the problem we are seeing on Debian installations:

```
Jun 23 01:32:57 debian10-64.example.com smart-proxy[10743]: /usr/lib/ruby/vendor_ruby/bundler_ext/output.rb:13:in `strict_err': Gem loading error: cannot load such file -- smart_proxy_dynflow (RuntimeError)
Jun 23 01:32:57 debian10-64.example.com smart-proxy[10743]:         from /usr/lib/ruby/vendor_ruby/bundler_ext/runtime.rb:46:in `rescue in block in system_require'
Jun 23 01:32:57 debian10-64.example.com smart-proxy[10743]:         from /usr/lib/ruby/vendor_ruby/bundler_ext/runtime.rb:39:in `block in system_require'
Jun 23 01:32:57 debian10-64.example.com smart-proxy[10743]:         from /usr/lib/ruby/vendor_ruby/bundler_ext/runtime.rb:37:in `each'
Jun 23 01:32:57 debian10-64.example.com smart-proxy[10743]:         from /usr/lib/ruby/vendor_ruby/bundler_ext/runtime.rb:37:in `system_require'
Jun 23 01:32:57 debian10-64.example.com smart-proxy[10743]:         from /usr/lib/ruby/vendor_ruby/bundler_ext.rb:19:in `block in system_require'
Jun 23 01:32:57 debian10-64.example.com smart-proxy[10743]:         from /usr/lib/ruby/vendor_ruby/bundler_ext.rb:14:in `each'
Jun 23 01:32:57 debian10-64.example.com smart-proxy[10743]:         from /usr/lib/ruby/vendor_ruby/bundler_ext.rb:14:in `system_require'
Jun 23 01:32:57 debian10-64.example.com smart-proxy[10743]:         from /usr/share/foreman-proxy/lib/bundler_helper.rb:22:in `require_groups'
Jun 23 01:32:57 debian10-64.example.com smart-proxy[10743]:         from /usr/share/foreman-proxy/lib/smart_proxy_main.rb:31:in `<top (required)>'
Jun 23 01:32:57 debian10-64.example.com smart-proxy[10743]:         from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
Jun 23 01:32:57 debian10-64.example.com smart-proxy[10743]:         from /usr/share/foreman-proxy/bin/smart-proxy:5:in `<main>'
Jun 23 01:32:57 debian10-64.example.com systemd[1]: foreman-proxy.service: Main process exited, code=exited, status=1/FAILURE
```

You can additionally see this over here: https://github.com/theforeman/puppet-foreman_proxy/pull/682/checks?check_run_id=2890268654