### PR TITLE
Fixes #32875 - Loosen required ruby version

### DIFF
--- a/smart_proxy_dynflow.gemspec
+++ b/smart_proxy_dynflow.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license = 'GPL-3.0'
 
-  gem.required_ruby_version = '~> 2.5'
+  gem.required_ruby_version = '>= 2.5'
 
   gem.add_runtime_dependency('dynflow', "~> 1.1")
   gem.add_runtime_dependency('rest-client')

--- a/smart_proxy_dynflow_core.gemspec
+++ b/smart_proxy_dynflow_core.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license = 'GPL-3.0'
 
-  gem.required_ruby_version = '~> 2.5'
-
   gem.add_development_dependency "bundler", ">= 1.7"
   gem.add_runtime_dependency('smart_proxy_dynflow', '~> 0.5')
 end


### PR DESCRIPTION
There is no real reason for not supporting ruby 3.