### PR TITLE
Fixes #33932 - allow cancellation of Group tasks

### DIFF
--- a/lib/smart_proxy_dynflow/action/output_collector.rb
+++ b/lib/smart_proxy_dynflow/action/output_collector.rb
@@ -4,5 +4,10 @@ module Proxy::Dynflow::Action
       output[:result] = []
       suspend
     end
+
+    def kill_run
+      execution_plan = world.persistence.load_execution_plan(caller_execution_plan_id)
+      execution_plan.cancel
+    end
   end
 end

--- a/lib/smart_proxy_dynflow/action/single_runner_batch.rb
+++ b/lib/smart_proxy_dynflow/action/single_runner_batch.rb
@@ -1,7 +1,10 @@
 module Proxy::Dynflow::Action
   class SingleRunnerBatch < Batch
+    include ::Dynflow::Action::Cancellable
+
     def plan(launcher, input_hash)
       launcher.launch_children(self, input_hash)
+      input[:group_runner_plan_id] = launcher.group_runner_plan_id
       sequence do
         results = plan_self
         plan_action BatchCallback, launcher.prepare_batch(input_hash), results.output[:results]
@@ -22,9 +25,7 @@ module Proxy::Dynflow::Action
     end
 
     def on_finish
-      output[:results] = sub_plans.map(&:entry_action).reduce({}) do |acc, cur|
-        acc.merge(cur.execution_plan_id => cur.output)
-      end
+      collect_outputs
     end
 
     def finalize
@@ -32,8 +33,20 @@ module Proxy::Dynflow::Action
       check_for_errors!
     end
 
+    def cancel!
+      collect_outputs
+      plan = world.persistence.load_execution_plan(input[:group_runner_plan_id])
+      plan&.cancel
+    end
+
     def rescue_strategy_for_self
       Dynflow::Action::Rescue::Skip
+    end
+
+    def collect_outputs
+      output[:results] = sub_plans.map(&:entry_action).reduce({}) do |acc, cur|
+        acc.merge(cur.execution_plan_id => cur.output)
+      end
     end
   end
 end

--- a/lib/smart_proxy_dynflow/task_launcher/group.rb
+++ b/lib/smart_proxy_dynflow/task_launcher/group.rb
@@ -3,6 +3,8 @@ require 'smart_proxy_dynflow/runner'
 module Proxy::Dynflow
   module TaskLauncher
     class AbstractGroup < Batch
+      attr_reader :group_runner_plan_id
+
       def self.runner_class
         raise NotImplementedError
       end
@@ -13,7 +15,8 @@ module Proxy::Dynflow
 
       def launch_children(parent, input_hash)
         super(parent, input_hash)
-        trigger(parent, Action::BatchRunner, self, input_hash)
+        runner_plan = trigger(parent, Action::BatchRunner, self, input_hash)
+        @group_runner_plan_id = runner_plan.execution_plan_id
       end
 
       def operation


### PR DESCRIPTION
Group tasks have only one Runner per Group.
This disable the ability to cancel single tasks.
It is only possible to cancel the whole batch, but we were not allowing even that.

To note: this will cancel the whole group, not just the single task obviously.
Is that something we want, or do we need the complete solution to indicate this on foreman side?

@adamruzicka opinions?