### PR TITLE
Fixes #34092 - Store even non-commited output chunks on finish

### DIFF
--- a/lib/smart_proxy_dynflow/action/runner.rb
+++ b/lib/smart_proxy_dynflow/action/runner.rb
@@ -74,7 +74,7 @@ module Proxy::Dynflow
       end
 
       def output_result
-        stored_output_chunks.map { |c| c[:chunk] }.reduce([], &:concat)
+        (stored_output_chunks + (@pending_output_chunks || [])).map { |c| c[:chunk] }.reduce([], &:concat)
       end
     end
   end


### PR DESCRIPTION
Output chunks are stored when the action is saved, but we we're aggregating them
into output[:result] before the final save so unsaved chunks didn't make it there.