### PR TITLE
Update Rubocop & use reusable workflows

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.ref_name }}
   cancel-in-progress: true
 
+env:
+  BUNDLE_WITHOUT: development
+
 jobs:
   rubocop:
     name: Rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 require 'rake'
 require 'rake/testtask'
-require 'rubocop/rake_task'
+
+begin
+  require 'rubocop/rake_task'
+rescue LoadError
+  # No Rubocop
+else
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.fail_on_error = true
+    task.formatters << 'github' if ENV['GITHUB_ACTIONS'] == 'true'
+  end
+end
 
 desc 'Default: run unit tests.'
 task :default => :test
@@ -19,13 +29,6 @@ end
 
 desc 'Test Dynflow plugin.'
 task :test do
-  Rake::Task['rubocop'].invoke if defined? RuboCop
+  Rake::Task['rubocop'].invoke if Rake::Task.task_defined?(:rubocop)
   Rake::Task['test:core'].invoke
-end
-
-if defined? RuboCop
-  desc 'Run RuboCop on the lib directory'
-  RuboCop::RakeTask.new(:rubocop) do |task|
-    task.fail_on_error = true
-  end
 end


### PR DESCRIPTION
This started as an effort to use reusable workflows within the Foreman project. Then I realized that the GitHub formatter in Rubocop was unavailable, so this also updates the version to a more recent one. It still has some errors left so don't consider this ready at all. At this point I just want to see if the workflow works and annotations are created.