### PR TITLE
Fixes #34616 - Create DB directory dynamically

### DIFF
--- a/lib/smart_proxy_dynflow/core.rb
+++ b/lib/smart_proxy_dynflow/core.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module Proxy::Dynflow
   class Core
     attr_accessor :world, :accepted_cert_serial
@@ -29,6 +31,7 @@ module Proxy::Dynflow
         Log.instance.warn "Could not open DB for dynflow at '#{db_file}', " \
                           "will keep data in memory. Restart will drop all dynflow data."
       else
+        FileUtils.mkdir_p(File.dirname(db_file))
         db_conn_string += "/#{db_file}"
       end
 


### PR DESCRIPTION
If the DB file is /var/lib/foreman-proxy/dynflow/dynflow.sqlite and /var/lib/foreman-proxy/dynflow doesn't exist, it fails. This ensures the directory exists. In practice foreman-proxy already creates /var/lib/foreman-proxy so this should work.

I haven't had a chance to verify this. @janniswarnat do you have a chance to verify this solves your problem?

Another solution is to keep the DB in memory which can be achieved by leaving the setting empty. This is what the foreman-installer does by default.