### PR TITLE
Fixes #34625 - Make execution plan cleaner more aggressive

### DIFF
--- a/lib/smart_proxy_dynflow/plugin.rb
+++ b/lib/smart_proxy_dynflow/plugin.rb
@@ -11,7 +11,7 @@ module Proxy::Dynflow
     settings_file "dynflow.yml"
     requires :foreman_proxy, ">= 1.16.0"
     default_settings :console_auth => true,
-                     :execution_plan_cleaner_age => 60 * 60 * 24
+                     :execution_plan_cleaner_age => 60 * 30
     plugin :dynflow, Proxy::Dynflow::VERSION
 
     capability(proc { self.available_operations })

--- a/settings.d/dynflow.yml.example
+++ b/settings.d/dynflow.yml.example
@@ -6,5 +6,5 @@
 # :console_auth: true
 
 # Maximum age of execution plans to keep before having them cleaned
-# by the execution plan cleaner (in seconds), defaults to 24 hours
-# :execution_plan_cleaner_age: 86400
+# by the execution plan cleaner (in seconds), defaults to 30 minutes
+# :execution_plan_cleaner_age: 1800


### PR DESCRIPTION
It will now wake up every half an hour and remove all execution plans
which have been stopped for at least half an hour. Half an hour should
give Foreman enough time to check up on the proxy in case the callback
from proxy fails, while not being too high at the same time.