### PR TITLE
Drop smart_proxy_dynflow Jenkins test changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ end
 
 group :test do
   gem 'minitest'
-  gem 'minitest-reporters'
   gem 'mocha'
   gem 'public_suffix'
   gem 'rack-test'

--- a/Rakefile
+++ b/Rakefile
@@ -29,8 +29,3 @@ if defined? RuboCop
     task.fail_on_error = true
   end
 end
-
-namespace :jenkins do
-  desc nil # No description means it's not listed in rake -T
-  task unit: :test
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,14 +6,11 @@ ENV['RACK_ENV'] = 'test'
 $LOAD_PATH << File.join(File.dirname(__FILE__), '..', '..', 'lib')
 require 'mocha/minitest'
 require "rack/test"
-require 'minitest/reporters'
 require 'smart_proxy_for_testing'
 
 require 'dynflow'
 require 'smart_proxy_dynflow'
 require 'smart_proxy_dynflow/testing'
-
-Minitest::Reporters.use!
 
 Proxy::Dynflow::Plugin.load_test_settings({})
 


### PR DESCRIPTION
For refernce: https://github.com/theforeman/smart_proxy_dynflow/pull/123#issuecomment-1646601180

We have GitHub Action to run the tests against different Ruby versions.