### PR TITLE
Improve RuboCop task definition in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,17 @@
 
 require 'rake'
 require 'rake/testtask'
-require 'rubocop/rake_task'
+
+begin
+  require 'rubocop/rake_task'
+rescue LoadError
+  # No Rubocop
+else
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.fail_on_error = true
+    task.formatters << 'github' if ENV['GITHUB_ACTIONS'] == 'true'
+  end
+end
 
 desc 'Default: run unit tests.'
 task :default => :test
@@ -20,13 +30,6 @@ end
 
 desc 'Test Dynflow plugin.'
 task :test do
-  Rake::Task['rubocop'].invoke if defined? RuboCop
+  Rake::Task['rubocop'].invoke if Rake::Task.task_defined?(:rubocop)
   Rake::Task['test:core'].invoke
-end
-
-if defined? RuboCop
-  desc 'Run RuboCop on the lib directory'
-  RuboCop::RakeTask.new(:rubocop) do |task|
-    task.fail_on_error = true
-  end
 end


### PR DESCRIPTION
This turns on the GitHub formatter if GH Actions is detected, which provides nice inline annotations.

Right now I added a commit to force failures, which showcases the feature.

This replaces the last part of https://github.com/theforeman/smart_proxy_dynflow/pull/104