### PR TITLE
Use non-deprecated license identifier

### DIFF
--- a/smart_proxy_dynflow.gemspec
+++ b/smart_proxy_dynflow.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
                           'LICENSE', 'Gemfile']
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.license = 'GPL-3.0'
+  gem.license = 'GPL-3.0-only'
 
   gem.required_ruby_version = '>= 2.7', '< 4'
 


### PR DESCRIPTION
CI on ruby 3.3 started failing with
```
WARNING:  License identifier 'GPL-3.0' is deprecated. Use an identifier from
https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
or set it to nil if you don't want to specify a license.
Did you mean 'AFL-3.0', 'APL-1.0', 'CPL-1.0', 'EPL-1.0', 'EPL-2.0', 'IPL-1.0', 'LPL-1.0', 'MPL-1.0', 'MPL-2.0', 'NPL-1.0', 'OPL-1.0', 'OSL-3.0', 'QPL-1.0', 'SPL-1.0', 'TPL-1.0', 'UPL-1.0', 'YPL-1.0', 'ZPL-2.0'?
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
```